### PR TITLE
Properly set the IP address in the request URL

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,10 +1,7 @@
 /* eslint-env jest*/
-const dns = require('dns')
 const listen = require('async-listen')
 const { createServer } = require('http')
 const cachedDNSFetch = require('./index')(require('node-fetch'))
-
-dns.setServers(['8.8.8.8', '1.1.1.1'])
 
 /**
  * Using `localtest.me` to use DNS to resolve to localhost

--- a/test.js
+++ b/test.js
@@ -1,7 +1,10 @@
 /* eslint-env jest*/
+const dns = require('dns')
 const listen = require('async-listen')
 const { createServer } = require('http')
 const cachedDNSFetch = require('./index')(require('node-fetch'))
+
+dns.setServers(['8.8.8.8', '1.1.1.1'])
 
 /**
  * Using `localtest.me` to use DNS to resolve to localhost
@@ -10,15 +13,21 @@ const cachedDNSFetch = require('./index')(require('node-fetch'))
 
 test('works with localtest.me', async () => {
   const server = createServer((req, res) => {
-    res.end('ha')
+    res.end(JSON.stringify({ url: req.url, headers: req.headers }))
   })
 
   await listen(server)
   const { port } = server.address()
 
-  const res = await cachedDNSFetch(`http://localtest.me:${port}`)
-  expect(await res.text()).toBe('ha')
-  server.close()
+  try {
+    const host = `localtest.me:${port}`
+    const res = await cachedDNSFetch(`http://${host}`)
+    const body = await res.json()
+    expect(res.url).toBe(`http://127.0.0.1:${port}/`)
+    expect(body.headers.host).toBe(host)
+  } finally {
+    server.close()
+  }
 })
 
 test('works with absolute redirects', async () => {
@@ -40,36 +49,46 @@ test('works with absolute redirects', async () => {
   portA = serverA.address().port
   portB = serverB.address().port
 
-  const res = await cachedDNSFetch(`http://localtest.me:${portA}`)
-  expect(await res.status).toBe(200)
-  expect(await res.text()).toBe(`localtest.me:${portB}`)
-
-  serverA.close()
-  serverB.close()
+  try {
+    const res = await cachedDNSFetch(`http://localtest.me:${portA}`)
+    expect(await res.status).toBe(200)
+    expect(await res.text()).toBe(`localtest.me:${portB}`)
+  } finally {
+    serverA.close()
+    serverB.close()
+  }
 })
 
 test('works with relative redirects', async () => {
   let count = 0
   const server = createServer((req, res) => {
-    if (count === 0) {
+    if (count++ === 0) {
       res.setHeader('Location', `/foo`)
       res.statusCode = 302
       res.end()
     } else {
-      res.end(req.url)
+      res.end(
+        JSON.stringify({
+          url: req.url,
+          host: req.headers.host
+        })
+      )
     }
-    count++
   })
-
   await listen(server)
   const { port } = server.address()
 
-  const res = await cachedDNSFetch(`http://localtest.me:${port}`)
-  expect(count).toBe(2)
-  expect(await res.status).toBe(200)
-  expect(await res.text()).toBe(`/foo`)
-
-  server.close()
+  try {
+    const host = `localtest.me:${port}`
+    const res = await cachedDNSFetch(`http://${host}`)
+    expect(count).toBe(2)
+    expect(await res.status).toBe(200)
+    const body = await res.json()
+    expect(body.url).toBe(`/foo`)
+    expect(body.host).toBe(host)
+  } finally {
+    server.close()
+  }
 })
 
 test('works with `headers` as an Object', async () => {
@@ -80,13 +99,16 @@ test('works with `headers` as an Object', async () => {
   await listen(server)
   const { port } = server.address()
 
-  const res = await cachedDNSFetch(`http://localtest.me:${port}`, {
-    headers: {
-      'X-Vercel': 'geist'
-    }
-  })
-  expect(await res.text()).toBe('geist')
-  server.close()
+  try {
+    const res = await cachedDNSFetch(`http://localtest.me:${port}`, {
+      headers: {
+        'X-Vercel': 'geist'
+      }
+    })
+    expect(await res.text()).toBe('geist')
+  } finally {
+    server.close()
+  }
 })
 
 test('works with `onRedirect` option to customize opts', async () => {
@@ -106,18 +128,20 @@ test('works with `onRedirect` option to customize opts', async () => {
   await listen(server)
   const { port } = server.address()
 
-  const options = {
-    onRedirect: jest.fn((res, opts) => {
-      opts.randomOption = true
-    })
+  try {
+    const options = {
+      onRedirect: jest.fn((res, opts) => {
+        opts.randomOption = true
+      })
+    }
+
+    await cachedDNSFetch(`http://localtest.me:${port}`, options)
+    expect(options.onRedirect.mock.calls.length).toBe(1)
+    const [res, opts] = options.onRedirect.mock.calls[0]
+    expect(res.status).toEqual(302)
+    expect(opts.headers).toBeDefined()
+    expect(opts.randomOption).toBe(true)
+  } finally {
+    server.close()
   }
-
-  await cachedDNSFetch(`http://localtest.me:${port}`, options)
-  expect(options.onRedirect.mock.calls.length).toBe(1)
-  const [res, opts] = options.onRedirect.mock.calls[0]
-  expect(res.status).toEqual(302)
-  expect(opts.headers).toBeDefined()
-  expect(opts.randomOption).toBe(true)
-
-  server.close()
 })

--- a/test.js
+++ b/test.js
@@ -1,7 +1,10 @@
 /* eslint-env jest*/
+const dns = require('dns')
 const listen = require('async-listen')
 const { createServer } = require('http')
 const cachedDNSFetch = require('./index')(require('node-fetch'))
+
+dns.setServers(['8.8.8.8', '1.1.1.1'])
 
 /**
  * Using `localtest.me` to use DNS to resolve to localhost
@@ -21,6 +24,7 @@ test('works with localtest.me', async () => {
     const res = await cachedDNSFetch(`http://${host}`)
     const body = await res.json()
     expect(res.url).toBe(`http://127.0.0.1:${port}/`)
+    expect(body.url).toBe(`/`)
     expect(body.headers.host).toBe(host)
   } finally {
     server.close()
@@ -67,7 +71,7 @@ test('works with relative redirects', async () => {
       res.end(
         JSON.stringify({
           url: req.url,
-          host: req.headers.host
+          headers: req.headers
         })
       )
     }
@@ -82,7 +86,7 @@ test('works with relative redirects', async () => {
     expect(await res.status).toBe(200)
     const body = await res.json()
     expect(body.url).toBe(`/foo`)
-    expect(body.host).toBe(host)
+    expect(body.headers.host).toBe(host)
   } finally {
     server.close()
   }

--- a/util.js
+++ b/util.js
@@ -1,0 +1,2 @@
+// Used for testing
+exports.dnsCachedUrl = Symbol('dnsCachedUrl')


### PR DESCRIPTION
So, this module was not working as expected. It works by first calling
`url.parse()` on the given URL. Then it does a DNS resolution on the
hostname, and resets the `hostname` property with the IP address.

Unfortunately, the `url.format()` function prefers the `host` property
over the `hostname` property, so setting `hostname` ends up being a no-op.

For example:

```
> process.version
'v12.18.4'

> const parsed = url.parse('https://example.com/hi')

// Reset `hostname`
> parsed.hostname = '1.2.3.4'
'1.2.3.4'

// `host` is preferred over `hostname`, so `url.format()` returns original URL
> url.format(parsed)
'https://example.com/hi'

> url.format(parsed) === parsed.href
true
```

This PR addresses that issue by overwriting both `host` and `hostname`
appropriately. Ensuring that the proper "Host" request header is set
during redirects is also addressed here, with additional tests.