### PR TITLE
Bump `@zeit/dns-cached-resolve` to `2.1.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@types/node-fetch": "2.3.2",
-    "@zeit/dns-cached-resolve": "2.1.0"
+    "@zeit/dns-cached-resolve": "2.1.2"
   },
   "devDependencies": {
     "@zeit/eslint-config-node": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,10 +443,10 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@zeit/dns-cached-resolve@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.0.tgz#78583010df1683fdb7b05949b75593c9a8641bc1"
-  integrity sha512-KD2zyRZEBNs9PJ3/ob7zx0CvR4wM0oV4G5s5gFfPwmM74GpFbUN2pAAivP2AXnUrJ14Nkh8NumNKOzOyc4LbFQ==
+"@zeit/dns-cached-resolve@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@zeit/dns-cached-resolve/-/dns-cached-resolve-2.1.2.tgz#2c2e33d682d67f94341c9a06ac0e2a8f14ff035f"
+  integrity sha512-A/5gbBskKPETTBqHwvlaW1Ri2orO62yqoFoXdxna1SQ7A/lXjpWgpJ1wdY3IQEcz5LydpS4sJ8SzI2gFyyLEhg==
   dependencies:
     "@types/async-retry" "1.2.1"
     "@types/lru-cache" "4.1.1"


### PR DESCRIPTION
Bump `@zeit/dns-cached-resolve` to `2.1.2` to ensure it resolves localhost.

Afterwards in can be bumped in https://github.com/vercel/fetch.

Fixes https://github.com/vercel/fetch-cached-dns/issues/3